### PR TITLE
Revert "Excavator:  Test libraries using the latest Java LTS"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,5 +46,4 @@ allprojects {
 javaVersions {
     libraryTarget = 11
     distributionTarget = 17
-    runtime = 21
 }

--- a/changelog/@unreleased/pr-6.v2.yml
+++ b/changelog/@unreleased/pr-6.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Revert "Excavator:  Test libraries using the latest Java LTS"'
+  links:
+  - https://github.com/palantir/gradle-failure-reports/pull/6


### PR DESCRIPTION
Reverts palantir/gradle-failure-reports#5


breaks develop with: 

```
> Could not resolve all task dependencies for configuration ':gradle-failure-reports:checkstyle'.
   > Could not resolve com.google.guava:guava:32.0.1-jre.
     Required by:
         project :gradle-failure-reports > com.puppycrawl.tools:checkstyle:10.12.5
      > Module 'com.google.guava:guava' has been rejected:
           Cannot select module with conflict on capability 'com.google.collections:google-collections:33.0.0-jre' also provided by [com.google.collections:google-collections:1.0(runtime)]
   > Could not resolve com.google.guava:guava:33.0.0-jre.
     Required by:
         project :gradle-failure-reports > project :
      > Module 'com.google.guava:guava' has been rejected:
           Cannot select module with conflict on capability 'com.google.collections:google-collections:33.0.0-jre' also provided by [com.google.collections:google-collections:1.0(runtime)]
   > Could not resolve com.google.collections:google-collections:1.0.
     Required by:
         project :gradle-failure-reports > com.puppycrawl.tools:checkstyle:10.12.5 > org.apache.maven.doxia:doxia-core:1.12.0 > org.codehaus.plexus:plexus-container-default:2.1.0
      > Module 'com.google.collections:google-collections' has been rejected:
           Cannot select module with conflict on capability 'com.google.collections:google-collections:1.0' also provided by [com.google.guava:guava:33.0.0-jre(jreRuntimeElements)]
          ```