### PR TITLE
Create FinalizerTask before subProjects FailureReportsProjectsPlugin plugin

### DIFF
--- a/changelog/@unreleased/pr-20.v2.yml
+++ b/changelog/@unreleased/pr-20.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Create FinalizerTask before subProjects FailureReportsProjectsPlugin
+    plugin
+  links:
+  - https://github.com/palantir/gradle-failure-reports/pull/20

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
@@ -45,13 +45,12 @@ public final class FailureReportsRootPlugin implements Plugin<Project> {
         }
         FailureReportsExtension failureReportsExtension =
                 project.getExtensions().create("failureReports", FailureReportsExtension.class);
-        project.getRootProject()
-                .allprojects(subProject -> subProject.getPlugins().apply(FailureReportsProjectsPlugin.class));
-
         TaskProvider<FinalizerTask> finalizerTask = project.getTasks()
                 .register(FINALIZER_TASK, FinalizerTask.class, task -> {
                     task.getOutputFile().set(failureReportsExtension.getFailureReportOutputFile());
                 });
+        project.getRootProject()
+                .allprojects(subProject -> subProject.getPlugins().apply(FailureReportsProjectsPlugin.class));
         collectVerifyLocksFailureReports(project, finalizerTask);
         collectOtherTaskFailures(project, finalizerTask);
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
[FailureReportsProjectsPlugin](https://github.com/palantir/gradle-failure-reports/blob/develop/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsProjectsPlugin.java#L47-L49) assumes the finalizerTask is already registered. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Create FinalizerTask before subProjects FailureReportsProjectsPlugin plugin
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
