### PR TITLE
Ignore test failures in the failure-reports

### DIFF
--- a/changelog/@unreleased/pr-31.v2.yml
+++ b/changelog/@unreleased/pr-31.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ignore test failures in the failure-reports
+  links:
+  - https://github.com/palantir/gradle-failure-reports/pull/31

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
 
 public final class FailureReportsRootPlugin implements Plugin<Project> {
 
@@ -89,6 +90,7 @@ public final class FailureReportsRootPlugin implements Plugin<Project> {
         return !(task instanceof JavaCompile
                 || task instanceof Checkstyle
                 || task instanceof FinalizerTask
+                || task instanceof Test
                 || task.getName().equals(VERIFY_LOCKS_TASK));
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Duplicated failure reports for failing tests.
![Screenshot 2024-02-26 at 2 44 56 PM](https://github.com/palantir/gradle-failure-reports/assets/25724655/2b384161-a91c-485a-a4d4-cfbc5b443e67)

The tests already generate a junit report that CircleCI can read. We should ignore the failures coming from the "Test" tasks.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

==COMMIT_MSG==
Ignore test failures in the failure-reports
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

