### PR TITLE
Only print error message once when formatting error output

### DIFF
--- a/changelog/@unreleased/pr-116.v2.yml
+++ b/changelog/@unreleased/pr-116.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Only print error message once when formatting error output
+  links:
+  - https://github.com/palantir/gradle-failure-reports/pull/116

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/util/ThrowableResources.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/util/ThrowableResources.java
@@ -38,9 +38,9 @@ public final class ThrowableResources {
                 "%s\n\n%s\n%s\n\n%s\n%s",
                 errorMessage,
                 CAUSAL_CHAIN,
-                causalChain,
+                causalChain.replace(errorMessage, ""),
                 EXCEPTION_MESSAGE,
-                Throwables.getStackTraceAsString(throwable));
+                Throwables.getStackTraceAsString(throwable).replace(errorMessage, ""));
     }
 
     public static String printThrowableCause(Throwable throwableCause) {

--- a/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/ThrowableFailureReporterTest.java
+++ b/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/ThrowableFailureReporterTest.java
@@ -35,9 +35,8 @@ public class ThrowableFailureReporterTest {
                 .startsWith(EXCEPTION_MESSAGE
                         + "\n\n* Causal chain is:\n\t"
                         + "com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: "
-                        + EXCEPTION_MESSAGE + "\n\n* Full exception is:\n"
-                        + "com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: "
-                        + EXCEPTION_MESSAGE);
+                        + "\n\n* Full exception is:\n"
+                        + "com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: ");
     }
 
     @Test

--- a/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/util/FailureReporterResourcesTest.java
+++ b/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/util/FailureReporterResourcesTest.java
@@ -58,8 +58,8 @@ public class FailureReporterResourcesTest {
     public void canFormatThrowable() {
         assertThat(ThrowableResources.formatThrowable(new GradleException("lock out of date")))
                 .contains("* Causal chain is:\n"
-                        + "\torg.gradle.api.GradleException: lock out of date\n\n"
+                        + "\torg.gradle.api.GradleException: \n\n"
                         + "* Full exception is:\n"
-                        + "org.gradle.api.GradleException: lock out of date");
+                        + "org.gradle.api.GradleException: ");
     }
 }

--- a/gradle-failure-reports/src/test/resources/expected-throwException-error-report.xml
+++ b/gradle-failure-reports/src/test/resources/expected-throwException-error-report.xml
@@ -19,11 +19,11 @@ Caused by: java.lang.OutOfMemoryError
 
 * Causal chain is:
 	org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':throwExceptionWithSuggestedFix'.
-	com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: ExceptionWithSuggestedFixMessage
+	com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: 
 
 * Full exception is:
 org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':throwExceptionWithSuggestedFix'.
-Caused by: com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: ExceptionWithSuggestedFixMessage
+Caused by: com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: 
 </failure>
     </testcase>
   </testsuite>
@@ -33,11 +33,11 @@ Caused by: com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion
 
 * Causal chain is:
 	org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':myProject:throwGradleException'.
-	org.gradle.api.GradleException: This is a normal gradle exception
+	org.gradle.api.GradleException: 
 
 * Full exception is:
 org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':myProject:throwGradleException'.
-Caused by: org.gradle.api.GradleException: This is a normal gradle exception
+Caused by: org.gradle.api.GradleException: 
 </failure>
     </testcase>
   </testsuite>
@@ -48,13 +48,13 @@ Caused by: org.gradle.api.GradleException: This is a normal gradle exception
 * Causal chain is:
 	org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':myProject:throwInnerExceptionWithSuggestedFix'.
 	org.gradle.api.GradleException: OuterGradleException
-	com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: InnerExceptionWithSuggestedFixMessage
+	com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: 
 	java.lang.RuntimeException: InnerRuntimeException
 
 * Full exception is:
 org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':myProject:throwInnerExceptionWithSuggestedFix'.
 Caused by: org.gradle.api.GradleException: OuterGradleException
-Caused by: com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: InnerExceptionWithSuggestedFixMessage
+Caused by: com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion: 
 	... PLACEHOLDER_NUMBER more
 Caused by: java.lang.RuntimeException: InnerRuntimeException
 	... PLACEHOLDER_NUMBER more


### PR DESCRIPTION
## Before this PR
Previously when an exception with suggestion or generic exception was caught, the error message was printed three times in Circle output since it's present in the causal chain and the stack trace.

## After this PR
Remove the error message from the causal chain and stack trace such that the error message is only printed once.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

