### PR TITLE
Option to ignore reporting failures for specific Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ apply plugin: 'com.palantir.failure-reports'
 ```
 
 The plugin generates a `build/failure-reports/build-TEST.xml` file which encapsulates the errors during the CircleCI job into a JUnit format.
+
+In situations where reporting from certain failed tasks should be ignored — such as for custom pytest tasks that already generate their own junit.xml files - Gradle plugin consumers can configure the plugin as follows:
+```groovy
+project.getPluginManager().withPlugin("com.palantir.failure-reports", _plugin -> {
+  FailureReportsExtension extension =
+          project.getExtensions().getByType(FailureReportsExtension.class);
+  extension.getIgnoredTasks().add(SomeTestTask.class);
+});
+```

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/BuildFailureReporter.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/BuildFailureReporter.java
@@ -30,6 +30,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
 
 public final class BuildFailureReporter {
 
@@ -66,7 +67,8 @@ public final class BuildFailureReporter {
     }
 
     private static boolean shouldTaskBeReported(Task task, List<Class<?>> ignoredClasses) {
-        return ignoredClasses.stream().noneMatch(ignoredClass -> ignoredClass.isInstance(task));
+        return !(task instanceof Test)
+                && ignoredClasses.stream().noneMatch(ignoredClass -> ignoredClass.isInstance(task));
     }
 
     private BuildFailureReporter() {}

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/BuildFailureReporter.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/BuildFailureReporter.java
@@ -21,6 +21,7 @@ import com.palantir.gradle.failurereports.common.FailureReport;
 import com.palantir.gradle.failurereports.junit.JunitReporter;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.gradle.api.Task;
@@ -29,23 +30,23 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.api.tasks.testing.Test;
 
 public final class BuildFailureReporter {
 
     private static Logger log = Logging.getLogger(BuildFailureReporter.class);
 
-    public static void report(File outputFile, Throwable buildThrowable) {
+    public static void report(File outputFile, Throwable buildThrowable, List<Class<?>> ignoredClasses) {
         Optional.ofNullable(buildThrowable).ifPresent(failure -> {
             try {
-                reportFailures(outputFile, failure);
+                reportFailures(outputFile, failure, ignoredClasses);
             } catch (IOException e) {
                 log.error("Failed to report build failures", e);
             }
         });
     }
 
-    private static void reportFailures(File outputFile, Throwable buildThrowable) throws IOException {
+    private static void reportFailures(File outputFile, Throwable buildThrowable, List<Class<?>> ignoredClasses)
+            throws IOException {
         ImmutableList.Builder<FailureReport> failureReports = ImmutableList.builder();
         for (TaskExecutionException taskExecutionException : BuildFailures.getTaskExecutionExceptions(buildThrowable)) {
             Task task = taskExecutionException.getTask();
@@ -56,12 +57,16 @@ public final class BuildFailureReporter {
             } else if (task instanceof Checkstyle checkstyle) {
                 failureReports.addAll(CheckstyleFailureReporter.collect(task.getProject(), checkstyle)
                         .collect(Collectors.toList()));
-            } else if (!(task instanceof Test)) {
+            } else if (shouldTaskBeReported(task, ignoredClasses)) {
                 // test failures are already reported
                 failureReports.add(ThrowableFailureReporter.getFailureReport(task));
             }
         }
         JunitReporter.reportFailures(outputFile, failureReports.build());
+    }
+
+    private static boolean shouldTaskBeReported(Task task, List<Class<?>> ignoredClasses) {
+        return ignoredClasses.stream().noneMatch(ignoredClass -> ignoredClass.isInstance(task));
     }
 
     private BuildFailureReporter() {}

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportFlowAction.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportFlowAction.java
@@ -20,6 +20,7 @@ import java.io.File;
 import org.gradle.api.flow.BuildWorkResult;
 import org.gradle.api.flow.FlowAction;
 import org.gradle.api.flow.FlowParameters;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.Input;
@@ -33,6 +34,9 @@ public final class FailureReportFlowAction implements FlowAction<FailureReportFl
         @Input
         Property<File> getOutputFile();
 
+        @Input
+        ListProperty<Class<?>> getIgnoredTasks();
+
         @ServiceReference
         Property<CompileFailuresService> getCompileFailuresService();
     }
@@ -43,7 +47,9 @@ public final class FailureReportFlowAction implements FlowAction<FailureReportFl
                 .getBuildResult()
                 .get()
                 .getFailure()
-                .ifPresent(failure ->
-                        BuildFailureReporter.report(parameters.getOutputFile().get(), failure));
+                .ifPresent(failure -> BuildFailureReporter.report(
+                        parameters.getOutputFile().get(),
+                        failure,
+                        parameters.getIgnoredTasks().get()));
     }
 }

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsExtension.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsExtension.java
@@ -20,7 +20,6 @@ import javax.inject.Inject;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.tasks.testing.Test;
 
 public abstract class FailureReportsExtension {
 
@@ -38,6 +37,5 @@ public abstract class FailureReportsExtension {
                 .convention(getProjectLayout().getBuildDirectory().file("failure-reports/build-TEST.xml"));
         getFailureReportCompileOutputFile()
                 .convention(getProjectLayout().getBuildDirectory().file("failure-reports/build-compile-TEST.xml"));
-        getIgnoredTasks().add(Test.class);
     }
 }

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsExtension.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsExtension.java
@@ -19,12 +19,16 @@ package com.palantir.gradle.failurereports;
 import javax.inject.Inject;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.testing.Test;
 
 public abstract class FailureReportsExtension {
 
     public abstract RegularFileProperty getFailureReportOutputFile();
 
     public abstract RegularFileProperty getFailureReportCompileOutputFile();
+
+    public abstract ListProperty<Class<?>> getIgnoredTasks();
 
     @Inject
     public abstract ProjectLayout getProjectLayout();
@@ -34,5 +38,6 @@ public abstract class FailureReportsExtension {
                 .convention(getProjectLayout().getBuildDirectory().file("failure-reports/build-TEST.xml"));
         getFailureReportCompileOutputFile()
                 .convention(getProjectLayout().getBuildDirectory().file("failure-reports/build-compile-TEST.xml"));
+        getIgnoredTasks().add(Test.class);
     }
 }

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsFlowActionsPlugin.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsFlowActionsPlugin.java
@@ -48,6 +48,7 @@ public abstract class FailureReportsFlowActionsPlugin implements Plugin<Project>
                     .set(failureReportsExtension.getFailureReportOutputFile().getAsFile());
             spec.getParameters().getBuildResult().set(getFlowProviders().getBuildWorkResult());
             spec.getParameters().getCompileFailuresService().set(compileFailuresService);
+            spec.getParameters().getIgnoredTasks().set(failureReportsExtension.getIgnoredTasks());
         });
     }
 }

--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
@@ -78,7 +78,8 @@ public final class FailureReportsRootPlugin implements Plugin<Project> {
                                     .getFailureReportOutputFile()
                                     .getAsFile()
                                     .get(),
-                            result.getFailure());
+                            result.getFailure(),
+                            failureReportsExtension.getIgnoredTasks().get());
                 }
             });
         }

--- a/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
+++ b/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
@@ -455,6 +455,45 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
+    def '#gradleVersionNumber: ignored task failures are not reported' () {
+        setup:
+        gradleVersion = gradleVersionNumber
+        // language=gradle
+        buildFile << '''
+            import com.palantir.gradle.failurereports.exceptions.ExceptionWithLogs
+
+            apply plugin: 'com.palantir.failure-reports'
+            apply plugin: 'java'
+
+            abstract class ParentCustomTask extends DefaultTask {}
+            abstract class MyCustomTask extends ParentCustomTask {}
+            
+            tasks.register('throwExceptionWithLogs', MyCustomTask.class) {
+                doLast {
+                    throw new ExceptionWithLogs("Failed after 2 attempts with exit code 1", "this is log line1\\nthis is log line 2", false)
+                }
+            }
+            
+            failureReports {
+                getIgnoredTasks().add(ParentCustomTask.class)
+            }
+        '''.stripIndent(true)
+
+        enableTestCiRun()
+
+        when:
+        ExecutionResult result = runTasksWithFailure( 'throwExceptionWithLogs', '--continue')
+
+        then:
+        result.failure.message.contains('Execution failed for task \':throwExceptionWithLogs\'.')
+
+        def reportXml = new File(projectDir, "build/failure-reports/build-TEST.xml")
+        !reportXml.exists()
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
+
 
     def '#gradleVersionNumber: when running locally, no failure report is created'() {
         setup:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Custom internal tasks that are running pytest task (https://pl.ntr/2wt) are reported on the first circle node. There is no option to ignore such tasks that are already producing a junit report for failures atm.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Adds an option to ignore specific tasks from showing in the failure reports generated by this plugin.
Consumers can specify ignored tasks by setting: 
```
project.getPluginManager().withPlugin("com.palantir.failure-reports", _plugin -> {
          FailureReportsExtension extension =
                  project.getExtensions().getByType(FailureReportsExtension.class);
          extension.getIgnoredTasks().add(SomeTestTask.class);
      });
```
==COMMIT_MSG==
Option to ignore reporting failures for specific Tasks
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

