### PR TITLE
Allow for subprojects to ignore tasks in failureReportsExtension

### DIFF
--- a/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
+++ b/gradle-failure-reports/src/main/java/com/palantir/gradle/failurereports/FailureReportsRootPlugin.java
@@ -49,12 +49,12 @@ public final class FailureReportsRootPlugin implements Plugin<Project> {
     }
 
     private static void applyFailureReportsPlugin(Project project) {
+        FailureReportsExtension failureReportsExtension =
+                ExtensionUtils.maybeCreate(project, "failureReports", FailureReportsExtension.class);
         if (!PluginResources.isRunningOnInitialCircleNode(project)) {
             return;
         }
 
-        FailureReportsExtension failureReportsExtension =
-                ExtensionUtils.maybeCreate(project, "failureReports", FailureReportsExtension.class);
         CompileFailuresService.getSharedCompileFailuresService(project, failureReportsExtension);
 
         project.allprojects(subproject -> subproject.getPluginManager().apply(FailureReportsProjectsPlugin.class));

--- a/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
+++ b/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
@@ -461,6 +461,7 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
         // language=gradle
         buildFile << '''
             import com.palantir.gradle.failurereports.exceptions.ExceptionWithLogs
+
             apply plugin: 'com.palantir.failure-reports'
             apply plugin: 'java'
             

--- a/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
+++ b/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
@@ -464,10 +464,10 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
 
             apply plugin: 'com.palantir.failure-reports'
             apply plugin: 'java'
-            
+
             abstract class ParentCustomTask extends DefaultTask {}
             abstract class MyCustomTask extends ParentCustomTask {}
-
+            
             tasks.register('throwExceptionWithLogs', MyCustomTask.class) {
                 doLast {
                     throw new ExceptionWithLogs("Failed after 2 attempts with exit code 1", "this is log line1\\nthis is log line 2", false)

--- a/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
+++ b/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
@@ -461,16 +461,14 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
         // language=gradle
         buildFile << '''
             import com.palantir.gradle.failurereports.exceptions.ExceptionWithLogs
-
-            apply plugin: 'com.palantir.failure-reports'
-            apply plugin: 'java'
-
+            apply plugin: 'com.palantir.failure-reports\'
+            apply plugin: 'java\'
             abstract class ParentCustomTask extends DefaultTask {}
             abstract class MyCustomTask extends ParentCustomTask {}
             
             tasks.register('throwExceptionWithLogs', MyCustomTask.class) {
                 doLast {
-                    throw new ExceptionWithLogs("Failed after 2 attempts with exit code 1", "this is log line1\\nthis is log line 2", false)
+                    throw new ExceptionWithLogs("Failed after 2 attempts with exit code 1", "this is log line1\\\\nthis is log line 2", false)
                 }
             }
             
@@ -479,13 +477,32 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
             }
         '''.stripIndent(true)
 
+        // language=gradle
+        addSubproject("mySubproject", '''
+            import com.palantir.gradle.failurereports.exceptions.ExceptionWithLogs
+            import com.palantir.gradle.failurereports.FailureReportsExtension
+            apply plugin: 'java'
+
+            abstract class SubProjectTask extends DefaultTask {}
+
+            tasks.register('throwExceptionWithLogsFromSubproject', SubProjectTask.class) {
+                doLast {
+                    throw new ExceptionWithLogs("Failed", "log line", false)
+                }
+            }
+
+            project.getRootProject().getPluginManager().withPlugin("com.palantir.failure-reports", _plugin -> {
+                 project.getRootProject().getExtensions().getByType(FailureReportsExtension.class).getIgnoredTasks().add(SubProjectTask.class)
+            })
+            '''.stripIndent())
         enableTestCiRun()
 
         when:
-        ExecutionResult result = runTasksWithFailure( 'throwExceptionWithLogs', '--continue')
+        ExecutionResult result = runTasksWithFailure( 'throwExceptionWithLogs', 'throwExceptionWithLogsFromSubproject', '--continue')
 
         then:
-        result.failure.message.contains('Execution failed for task \':throwExceptionWithLogs\'.')
+        getThrowableCauses(result.failure).stream().filter(it -> it.message.contains('Execution failed for task \':throwExceptionWithLogs\'.')
+                || it.message.contains('Execution failed for task \':mySubproject:throwExceptionWithLogsFromSubproject\'.')).count() == 2
 
         def reportXml = new File(projectDir, "build/failure-reports/build-TEST.xml")
         !reportXml.exists()
@@ -647,5 +664,16 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
 
     private Path getDefaultOutputFile(String gradleVersionNumber) {
         return Path.of(projectDir.getPath()).resolve(String.format('build/failure-reports/unit-test-%s.xml', gradleVersionNumber));
+    }
+
+
+    private static List<Throwable> getThrowableCauses(Throwable failure) {
+        List<Throwable> causes = new ArrayList<>();
+        Throwable cause = failure.getCause();
+        while (cause != null && !causes.contains(cause)) {
+            causes.add(cause);
+            cause = cause.getCause();
+        }
+        return causes;
     }
 }

--- a/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
+++ b/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
@@ -461,8 +461,9 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
         // language=gradle
         buildFile << '''
             import com.palantir.gradle.failurereports.exceptions.ExceptionWithLogs
-            apply plugin: 'com.palantir.failure-reports\'
-            apply plugin: 'java\'
+            apply plugin: 'com.palantir.failure-reports'
+            apply plugin: 'java'
+            
             abstract class ParentCustomTask extends DefaultTask {}
             abstract class MyCustomTask extends ParentCustomTask {}
             

--- a/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
+++ b/gradle-failure-reports/src/test/groovy/com/palantir/gradle/failurereports/FailureReportsProjectsPluginIntegrationSpec.groovy
@@ -466,10 +466,10 @@ class FailureReportsProjectsPluginIntegrationSpec extends IntegrationSpec {
             
             abstract class ParentCustomTask extends DefaultTask {}
             abstract class MyCustomTask extends ParentCustomTask {}
-            
+
             tasks.register('throwExceptionWithLogs', MyCustomTask.class) {
                 doLast {
-                    throw new ExceptionWithLogs("Failed after 2 attempts with exit code 1", "this is log line1\\\\nthis is log line 2", false)
+                    throw new ExceptionWithLogs("Failed after 2 attempts with exit code 1", "this is log line1\\nthis is log line 2", false)
                 }
             }
             


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Related to https://pl.ntr/2wR


## After this PR
Making sure the root failureReports extension is always created. Added a test to confirm that subprojects can customize the ignoredTasks

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow for subprojects to ignore tasks in failureReportsExtension
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

