### PR TITLE
Fix `develop` - stop printing diagnostic `Picked up _JAVA_OPTIONS`

### DIFF
--- a/gradle-failure-reports/build.gradle
+++ b/gradle-failure-reports/build.gradle
@@ -46,7 +46,11 @@ tasks.named('test', {
     // ignore deprecation warnings for gradle 9.0 found by nebula-test
     systemProperty 'ignoreDeprecations', 'true'
 
-    // _JAVA_OPTIONS for main build leaking into test builds. Printing superfluous diagnostic logs that only fail in circle.
-    environment '_JAVA_OPTIONS', ''
+    // _JAVA_OPTIONS for the main build is leaking into test builds. This ends up non-deterministically printing
+    // superfluous diagnostic logs that only fail in circle - as we explicitly set _JAVA_OPTIONS in circle to control
+    // the gradle build.
+    def newEnvironment  = new HashMap(environment)
+    newEnvironment.remove("_JAVA_OPTIONS")
+    environment = newEnvironment
 })
 

--- a/gradle-failure-reports/build.gradle
+++ b/gradle-failure-reports/build.gradle
@@ -45,12 +45,5 @@ gradlePlugin {
 tasks.named('test', {
     // ignore deprecation warnings for gradle 9.0 found by nebula-test
     systemProperty 'ignoreDeprecations', 'true'
-
-    // _JAVA_OPTIONS for the main build is leaking into test builds. This ends up non-deterministically printing
-    // superfluous diagnostic logs that only fail in circle - as we explicitly set _JAVA_OPTIONS in circle to control
-    // the gradle build.
-    def newEnvironment  = new HashMap(environment)
-    newEnvironment.remove("_JAVA_OPTIONS")
-    environment = newEnvironment
 })
 

--- a/gradle-failure-reports/build.gradle
+++ b/gradle-failure-reports/build.gradle
@@ -45,5 +45,8 @@ gradlePlugin {
 tasks.named('test', {
     // ignore deprecation warnings for gradle 9.0 found by nebula-test
     systemProperty 'ignoreDeprecations', 'true'
+
+    // _JAVA_OPTIONS for main build leaking into test builds. Printing superfluous diagnostic logs that only fail in circle.
+    environment '_JAVA_OPTIONS', ''
 })
 

--- a/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/CheckedInExpectedReports.java
+++ b/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/CheckedInExpectedReports.java
@@ -40,7 +40,7 @@ public final class CheckedInExpectedReports {
     private static final String PROJECT_DIR_PLACEHOLDER = "_PROJECT_DIR";
     private static final String OTHER_STACK_FRAMES_REGEX = "(?m)^\\sat (?!com\\.palantir\\.).*\n";
     private static final String STACKFRAME_MORE_REGEX = "... \\d+ more";
-    private static final String JAVA_OPTIONS_REGEX = "(?m)^\\s+Picked up _JAVA_OPTIONS.*\n";
+    private static final String JAVA_OPTIONS_REGEX = "(?m)^\\s*Picked up _JAVA_OPTIONS.*\n";
 
     /**
      * When ran _locally_, it copies the generated reports from the tests to the "src/test/resources/" path.

--- a/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/CheckedInExpectedReports.java
+++ b/gradle-failure-reports/src/test/java/com/palantir/gradle/failurereports/CheckedInExpectedReports.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public final class CheckedInExpectedReports {
     private static final String PROJECT_DIR_PLACEHOLDER = "_PROJECT_DIR";
     private static final String OTHER_STACK_FRAMES_REGEX = "(?m)^\\sat (?!com\\.palantir\\.).*\n";
     private static final String STACKFRAME_MORE_REGEX = "... \\d+ more";
+    private static final String JAVA_OPTIONS_REGEX = "(?m)^\\s+Picked up _JAVA_OPTIONS.*\n";
 
     /**
      * When ran _locally_, it copies the generated reports from the tests to the "src/test/resources/" path.
@@ -72,8 +73,11 @@ public final class CheckedInExpectedReports {
 
     private static String getReportWithProjectPlaceholder(Path reportPath, Path projectDir) throws IOException {
         return maybeRedactStacktrace(Files.readString(reportPath)
-                // if local paths are too big, they might get truncated in the errorMessage
-                .replaceAll(projectDir.toString(), PROJECT_DIR_PLACEHOLDER));
+                        // if local paths are too big, they might get truncated in the errorMessage
+                        .replaceAll(projectDir.toString(), PROJECT_DIR_PLACEHOLDER))
+                // if a new java process is started during a task run, _JAVA_OPTIONS will be captured and prevent
+                // comparison
+                .replaceAll(JAVA_OPTIONS_REGEX, "");
     }
 
     private static boolean runningInCi() {


### PR DESCRIPTION
## Before this PR
PRs have been non-deterministically failing at least for the last 2 weeks (I did not check further) on the test `Multiple project errors are reported`. 

```xml
<testsuites>
    <testsuite name="myProject1/src/main/java/app/ClassFoo.java:6" tests="1">
      <testcase name="ClassFoo.java:6: error: illegal start of expression" classname="myProject1/src/main/java/app/ClassFoo.java:6">
        <failure type="ERROR">_PROJECT_DIR/myProject1/src/main/java/app/ClassFoo.java:6: error: illegal start of expression
          / wrong
          ^
  _PROJECT_DIR/myProject1/src/main/java/app/ClassFoo.java:6: error: ';' expected
          / wrong
                 ^
  Picked up _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -XX:MaxRAM=8g -XX:+CrashOnOutOfMemoryError -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
  </failure>
      </testcase>
    </testsuite>
    <testsuite name="myProject2/src/main/java/app/ClassA.java:4" tests="1">
      <testcase name="ClassA.java:4: error: cannot find symbol" classname="myProject2/src/main/java/app/ClassA.java:4">
        <failure type="ERROR">_PROJECT_DIR/myProject2/src/main/java/app/ClassA.java:4: error: cannot find symbol
  public class ClassA extends AnotherClass {
                              ^
    symbol: class AnotherClass
  </failure>
      </testcase>
    </testsuite>
  </testsuites>
```

Namely:

    Picked up _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -XX:MaxRAM=8g -XX:+CrashOnOutOfMemoryError -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts

This is something that is added in circle's config to control the gradle build of the repository, not necessarily the gradle builds under test. It doesn't appear to manifest locally (seeing as we don't set it), and it is also non-deterministic. Sometimes it appears at that point, sometimes it doesn't. 

My guess is that it is whenever a new java process is launched either for a new test worker or something else, it will read this as it is inherited from the parent gradle build process which has been configured by circle's configuration file.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

~Somewhat crude, but figured we can just delete the key out of the environment before running the test. Other alternatives considered:~
 * ~doing redaction of the xml file, similar to how we do it for `_PROJECT_DIR`.~
 * ~I think this is a bit more brittle, but can go this direction if it makes sense.~

Gone in the direction of the redaction. At the very least we don't have to worry about test setup that's *outside* of junit.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

